### PR TITLE
Role remove submitted

### DIFF
--- a/apps/api/db/deploy/tables.sql
+++ b/apps/api/db/deploy/tables.sql
@@ -69,7 +69,6 @@ CREATE TABLE application (
 	id integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
 	role_id integer NOT NULL,
 	cover_letter text NOT NULL,
-	submitted boolean NOT NULL,
 	date_submitted timestamptz
 );
 

--- a/apps/api/db/verify/tables.sql
+++ b/apps/api/db/verify/tables.sql
@@ -93,7 +93,6 @@ SELECT
 	id,
 	role_id,
 	cover_letter,
-	submitted,
 	date_submitted
 FROM
 	"application"

--- a/apps/api/src/controllers/__tests__/role.test.ts
+++ b/apps/api/src/controllers/__tests__/role.test.ts
@@ -99,6 +99,7 @@ describe("handleGetRolePreviews", () => {
 		const rolePreviewsResponse = rolePreviews.map((rp) => ({
 			...rp,
 			date_added: rp.date_added.toISOString(),
+			date_submitted: rp.date_submitted?.toISOString() ?? null,
 		}));
 
 		beforeEach(() => {

--- a/apps/api/src/controllers/__tests__/role.test.ts
+++ b/apps/api/src/controllers/__tests__/role.test.ts
@@ -86,13 +86,13 @@ describe("handleGetRolePreviews", () => {
 			const { id: company_id, name: company } = generateCompany();
 			const role = generateRole(company_id);
 			const { location } = generateRoleLocationData(role.id);
-			const { submitted } = generateApplicationData(role.id);
+			const { date_submitted } = generateApplicationData(role.id);
 
 			return {
 				company,
 				...role,
 				location,
-				submitted,
+				date_submitted,
 			};
 		});
 

--- a/apps/api/src/controllers/role.ts
+++ b/apps/api/src/controllers/role.ts
@@ -36,6 +36,7 @@ export const handleGetRolePreviews: RequestHandler<RolePreviewJson[]> = async (
 			rolePreviews.map((rp) => ({
 				...rp,
 				date_added: rp.date_added.toISOString(),
+				date_submitted: rp.date_submitted?.toISOString() ?? null,
 			})),
 		);
 	} catch (error) {

--- a/apps/api/src/models/__tests__/role.model.integration.test.ts
+++ b/apps/api/src/models/__tests__/role.model.integration.test.ts
@@ -48,14 +48,14 @@ describe("getRolePreviews", () => {
 		const rolePreviews: RolePreview[] = await Promise.all(
 			companies.map(async ({ id: company_id, name: company }) => {
 				const role = await seedRole(company_id);
-				const roleLocation = await seedRoleLocation(role.id);
-				const application = await seedApplication(role.id);
+				const { location } = await seedRoleLocation(role.id);
+				const { date_submitted } = await seedApplication(role.id);
 
 				return {
 					company,
 					...role,
-					location: roleLocation.location,
-					submitted: application.submitted,
+					location,
+					date_submitted,
 				};
 			}),
 		);

--- a/apps/api/src/models/role.ts
+++ b/apps/api/src/models/role.ts
@@ -19,7 +19,7 @@ async function addRole({ title, company_id, ad_url, notes }: RoleInitializer) {
 async function getRolePreviews(): Promise<RolePreview[]> {
 	try {
 		const rolePreviews = await db.manyOrNone<RolePreview>(
-			`SELECT r.id, r.company_id, r.title, r.ad_url, r.notes, r.date_added, c.name AS company, rl.location, a.submitted
+			`SELECT r.id, r.company_id, r.title, r.ad_url, r.notes, r.date_added, c.name AS company, rl.location, a.date_submitted
          FROM role r
          JOIN company c ON r.company_id = c.id
   		 LEFT JOIN role_location rl ON rl.role_id = r.id

--- a/apps/api/src/routes/__tests__/role.routes.integration.test.ts
+++ b/apps/api/src/routes/__tests__/role.routes.integration.test.ts
@@ -167,16 +167,15 @@ describe("GET /api/roles/previews", () => {
 				.get("/api/roles/previews")
 				.set("Cookie", [`session=${JSON.stringify({ id: session.id })}`]);
 
-			const rolePreviewsWithDateAddedString = rolePreviews.map(
-				({ date_added, ...rest }) => ({
+			const rolePreviewsJson = rolePreviews.map(
+				({ date_added, date_submitted, ...rest }) => ({
 					date_added: date_added.toISOString(),
+					date_submitted: date_submitted?.toISOString() ?? null,
 					...rest,
 				}),
 			);
 
-			expect(response.body).toIncludeSameMembers(
-				rolePreviewsWithDateAddedString,
-			);
+			expect(response.body).toIncludeSameMembers(rolePreviewsJson);
 		});
 	});
 

--- a/apps/api/src/routes/__tests__/role.routes.integration.test.ts
+++ b/apps/api/src/routes/__tests__/role.routes.integration.test.ts
@@ -124,13 +124,13 @@ describe("GET /api/roles/previews", () => {
 			companies.map(async ({ id: company_id, name: company }) => {
 				const role = await seedRole(company_id);
 				const { location } = await seedRoleLocation(role.id);
-				const { submitted } = await seedApplication(role.id);
+				const { date_submitted } = await seedApplication(role.id);
 
 				return {
 					company,
 					...role,
 					location,
-					submitted,
+					date_submitted,
 				};
 			}),
 		);

--- a/apps/api/src/testUtils/dbHelpers.ts
+++ b/apps/api/src/testUtils/dbHelpers.ts
@@ -74,14 +74,14 @@ export async function seedRoleLocation(roleId: RoleId): Promise<RoleLocation> {
 }
 
 export async function seedApplication(roleId: RoleId): Promise<Application> {
-	const { cover_letter, date_submitted, role_id, submitted } =
+	const { cover_letter, date_submitted, role_id } =
 		generateApplicationData(roleId);
 
 	const application = await db.one<Application>(
-		`INSERT INTO application (cover_letter, date_submitted, role_id, submitted)
+		`INSERT INTO application (cover_letter, date_submitted, role_id)
 		VALUES ($1, $2, $3, $4)
-		RETURNING id, cover_letter, date_submitted, role_id, submitted`,
-		[cover_letter, date_submitted, role_id, submitted],
+		RETURNING id, cover_letter, date_submitted, role_id`,
+		[cover_letter, date_submitted, role_id],
 	);
 
 	return application;

--- a/apps/api/src/testUtils/dbHelpers.ts
+++ b/apps/api/src/testUtils/dbHelpers.ts
@@ -79,7 +79,7 @@ export async function seedApplication(roleId: RoleId): Promise<Application> {
 
 	const application = await db.one<Application>(
 		`INSERT INTO application (cover_letter, date_submitted, role_id)
-		VALUES ($1, $2, $3, $4)
+		VALUES ($1, $2, $3)
 		RETURNING id, cover_letter, date_submitted, role_id`,
 		[cover_letter, date_submitted, role_id],
 	);

--- a/apps/jobs-dashboard/src/components/RoleCard.tsx
+++ b/apps/jobs-dashboard/src/components/RoleCard.tsx
@@ -7,7 +7,7 @@ export function RoleCard({
 	ad_url,
 	date_added,
 	location,
-	submitted,
+	date_submitted,
 }: RolePreviewJson) {
 	const dateAddedString = new Date(date_added).toDateString();
 
@@ -20,7 +20,11 @@ export function RoleCard({
 
 				{location && <p className="role-card__location"> {location}</p>}
 				<p>Added: {dateAddedString}</p>
-				<p>{submitted ? "Submitted" : "Not Submitted"}</p>
+				<p>
+					{date_submitted
+						? `Submitted: ${new Date(date_submitted).toDateString()}`
+						: "Not Submitted"}
+				</p>
 				{ad_url && <a href={ad_url}>View Ad</a>}
 			</div>
 			<div className="role-card__notes">

--- a/apps/jobs-dashboard/src/components/__tests__/RoleCard.test.tsx
+++ b/apps/jobs-dashboard/src/components/__tests__/RoleCard.test.tsx
@@ -1,9 +1,11 @@
+import { faker } from "@faker-js/faker";
 import {
 	generateApplicationData,
 	generateCompany,
 	generateRole,
 	generateRoleLocationData,
 } from "@repo/shared/testHelpers/generators";
+import { RolePreviewJson } from "@repo/shared/types/rolePreview";
 import { render, screen } from "@testing-library/react";
 import { RoleCard } from "../RoleCard";
 
@@ -12,48 +14,36 @@ describe("RoleCard", () => {
 
 	const role = generateRole(companyId);
 	const { location } = generateRoleLocationData(role.id);
-	const { submitted } = generateApplicationData(role.id);
+	const { date_submitted } = generateApplicationData(role.id);
 
-	const rolePreview = {
+	const rolePreview: RolePreviewJson = {
 		...role,
 		company,
 		location,
-		submitted,
 		date_added: role.date_added.toISOString(),
+		date_submitted: date_submitted?.toISOString() ?? null,
 	};
 
-	function renderRoleCard(submitted?: "submitted" | "not submitted") {
-		const submittedProp = submitted
-			? {
-					submitted: submitted === "submitted",
-				}
-			: {
-					submitted: rolePreview.submitted,
-				};
-
-		render(<RoleCard {...rolePreview} {...submittedProp} />);
-	}
-
 	it("displays the role title", () => {
-		renderRoleCard();
+		render(<RoleCard {...rolePreview} />);
 
 		expect(screen.getByText(role.title)).toBeVisible();
 	});
 
 	it("displays the company", () => {
-		renderRoleCard();
+		render(<RoleCard {...rolePreview} />);
 
 		expect(screen.getByText(company)).toBeVisible();
 	});
 
 	it("displays the notes", () => {
-		renderRoleCard();
+		render(<RoleCard {...rolePreview} />);
 
 		expect(screen.getByText(role.notes)).toBeVisible();
 	});
 
 	it("displays a link to the ad", () => {
-		renderRoleCard();
+		render(<RoleCard {...rolePreview} />);
 
 		const link = screen.getByRole("link");
 
@@ -62,7 +52,7 @@ describe("RoleCard", () => {
 	});
 
 	it("displays the date the role was added to the dashboard", () => {
-		renderRoleCard();
+		render(<RoleCard {...rolePreview} />);
 
 		expect(
 			screen.getByText(`Added: ${new Date(role.date_added).toDateString()}`),
@@ -71,15 +61,23 @@ describe("RoleCard", () => {
 
 	describe("when the role has been submitted", () => {
 		it("displays submitted", () => {
-			renderRoleCard("submitted");
+			const submitted_date = faker.date.recent();
+			render(
+				<RoleCard
+					{...rolePreview}
+					date_submitted={submitted_date.toISOString()}
+				/>,
+			);
 
-			expect(screen.getByText("Submitted")).toBeVisible();
+			expect(
+				screen.getByText(`Submitted: ${submitted_date.toDateString()}`),
+			).toBeVisible();
 		});
 	});
 
 	describe("when the role has not been submitted", () => {
 		it("displays Not Submitted", () => {
-			renderRoleCard("not submitted");
+			render(<RoleCard {...rolePreview} date_submitted={null} />);
 
 			expect(screen.getByText("Not Submitted")).toBeVisible();
 		});

--- a/packages/shared/generated/db/hire_me/Application.ts
+++ b/packages/shared/generated/db/hire_me/Application.ts
@@ -15,8 +15,6 @@ export default interface Application {
 
 	cover_letter: string;
 
-	submitted: boolean;
-
 	date_submitted: Date | null;
 }
 
@@ -25,8 +23,6 @@ export interface ApplicationInitializer {
 	role_id: RoleId;
 
 	cover_letter: string;
-
-	submitted: boolean;
 
 	date_submitted?: Date | null;
 }
@@ -37,8 +33,6 @@ export interface ApplicationMutator {
 
 	cover_letter?: string;
 
-	submitted?: boolean;
-
 	date_submitted?: Date | null;
 }
 
@@ -48,7 +42,6 @@ export const application = z.object({
 	id: applicationId,
 	role_id: roleId,
 	cover_letter: z.string(),
-	submitted: z.boolean(),
 	date_submitted: z.date().nullable(),
 }) as unknown as z.Schema<Application>;
 
@@ -56,7 +49,6 @@ export const applicationInitializer = z.object({
 	id: applicationId.optional(),
 	role_id: roleId,
 	cover_letter: z.string(),
-	submitted: z.boolean(),
 	date_submitted: z.date().optional().nullable(),
 }) as unknown as z.Schema<ApplicationInitializer>;
 
@@ -64,6 +56,5 @@ export const applicationMutator = z.object({
 	id: applicationId.optional(),
 	role_id: roleId.optional(),
 	cover_letter: z.string().optional(),
-	submitted: z.boolean().optional(),
 	date_submitted: z.date().optional().nullable(),
 }) as unknown as z.Schema<ApplicationMutator>;

--- a/packages/shared/testHelpers/generators.ts
+++ b/packages/shared/testHelpers/generators.ts
@@ -94,7 +94,6 @@ export function generateApplicationData(
 	return {
 		role_id: roleId,
 		cover_letter: faker.lorem.sentences(),
-		submitted,
 		date_submitted: submitted ? faker.date.recent() : null,
 	};
 }

--- a/packages/shared/types/rolePreview.ts
+++ b/packages/shared/types/rolePreview.ts
@@ -9,6 +9,8 @@ export interface RolePreview extends Role {
 	date_submitted: Application["date_submitted"] | null;
 }
 
-export interface RolePreviewJson extends Omit<RolePreview, "date_added"> {
+export interface RolePreviewJson
+	extends Omit<RolePreview, "date_added" | "date_submitted"> {
 	date_added: string;
+	date_submitted: string | null;
 }

--- a/packages/shared/types/rolePreview.ts
+++ b/packages/shared/types/rolePreview.ts
@@ -6,7 +6,7 @@ import RoleLocation from "../generated/db/hire_me/RoleLocation.js";
 export interface RolePreview extends Role {
 	company: Company["name"];
 	location: RoleLocation["location"] | null;
-	submitted: Application["submitted"] | null;
+	date_submitted: Application["date_submitted"] | null;
 }
 
 export interface RolePreviewJson extends Omit<RolePreview, "date_added"> {


### PR DESCRIPTION
- Remove `submitted` column from `Application` table
  - Since `date_submitted` column exists and is nullable, it can be used to determine if application has been submitted
- Update API and jobs-dashboard to accommodate above change