### PR TITLE
Use differentiated generated types

### DIFF
--- a/apps/api/src/controllers/__tests__/admin.test.ts
+++ b/apps/api/src/controllers/__tests__/admin.test.ts
@@ -28,7 +28,7 @@ describe("handleLogin", () => {
 			const { id, expiry } = generateAdminSession(adminId);
 
 			beforeEach(() => {
-				mockLogin.mockResolvedValue({ id, expiry });
+				mockLogin.mockResolvedValue({ id, expiry: expiry.toISOString() });
 			});
 
 			it("responds with a 204 status code", async () => {

--- a/apps/api/src/controllers/__tests__/requirement.test.ts
+++ b/apps/api/src/controllers/__tests__/requirement.test.ts
@@ -1,4 +1,3 @@
-import Requirement from "@repo/shared/generated/db/hire_me/Requirement";
 import {
 	generateCompany,
 	generateRequirement,
@@ -19,7 +18,7 @@ beforeEach(() => {
 describe("handleAddRequirement", () => {
 	const { id: company_id } = generateCompany();
 	const { id: role_id } = generateRole(company_id);
-	const requirement: Requirement = generateRequirement(role_id);
+	const requirement = generateRequirement(role_id);
 
 	describe("when the requirement is successfully added", () => {
 		const req = getMockReq({

--- a/apps/api/src/controllers/__tests__/role.test.ts
+++ b/apps/api/src/controllers/__tests__/role.test.ts
@@ -44,7 +44,10 @@ describe("handleAddRole", () => {
 		it("returns the role", async () => {
 			await handleAddRole(req, res, next);
 
-			expect(res.json).toHaveBeenCalledWith(role);
+			expect(res.json).toHaveBeenCalledWith({
+				...role,
+				date_added: role.date_added.toISOString(),
+			});
 		});
 	});
 

--- a/apps/api/src/controllers/admin.ts
+++ b/apps/api/src/controllers/admin.ts
@@ -23,7 +23,7 @@ export const handleLogin: RequestHandler<undefined, UserCredentials> = async (
 			.cookie("session", JSON.stringify({ id }), {
 				domain: "localhost",
 				path: "/api",
-				expires: expiry,
+				expires: new Date(expiry),
 			})
 			.send();
 		return;

--- a/apps/api/src/controllers/company.ts
+++ b/apps/api/src/controllers/company.ts
@@ -1,13 +1,13 @@
-import DBCompany, {
-	DBCompanyInitializer,
-} from "@repo/shared/generated/db/hire_me/Company";
+import Company, {
+	CompanyInitializer,
+} from "@repo/shared/generated/api/hire_me/Company";
 import { ReasonPhrases, StatusCodes } from "http-status-codes";
 import { companyErrorCodes, companyModel } from "../models/company";
 import { RequestHandler } from "./sharedTypes";
 
 export const handleAddCompany: RequestHandler<
-	DBCompany,
-	DBCompanyInitializer
+	Company,
+	CompanyInitializer
 > = async (req, res) => {
 	try {
 		const company = await companyModel.addCompany(req.body);
@@ -33,10 +33,7 @@ export const handleAddCompany: RequestHandler<
 	}
 };
 
-export const handleGetCompanies: RequestHandler<DBCompany[]> = async (
-	_,
-	res,
-) => {
+export const handleGetCompanies: RequestHandler<Company[]> = async (_, res) => {
 	try {
 		const companies = await companyModel.getCompanies();
 		res.json(companies);

--- a/apps/api/src/controllers/requirement.ts
+++ b/apps/api/src/controllers/requirement.ts
@@ -1,13 +1,13 @@
-import DBRequirement, {
-	DBRequirementInitializer,
-} from "@repo/shared/generated/db/hire_me/Requirement";
+import Requirement, {
+	RequirementInitializer,
+} from "@repo/shared/generated/api/hire_me/Requirement";
 import { ReasonPhrases, StatusCodes } from "http-status-codes";
 import { requirementModel } from "../models/requirement";
 import { RequestHandler } from "./sharedTypes";
 
 export const handleAddRequirement: RequestHandler<
-	DBRequirement,
-	DBRequirementInitializer
+	Requirement,
+	RequirementInitializer
 > = async (req, res) => {
 	try {
 		const requirement = await requirementModel.addRequirement(req.body);

--- a/apps/api/src/controllers/role.ts
+++ b/apps/api/src/controllers/role.ts
@@ -1,18 +1,19 @@
-import DBRole, {
-	DBRoleInitializer,
-} from "@repo/shared/generated/db/hire_me/Role";
+import Role, { RoleInitializer } from "@repo/shared/generated/api/hire_me/Role";
 import { RolePreviewJson } from "@repo/shared/types/rolePreview";
 import { ReasonPhrases, StatusCodes } from "http-status-codes";
 import { roleModel } from "../models/role";
 import { RequestHandler } from "./sharedTypes";
 
-export const handleAddRole: RequestHandler<DBRole, DBRoleInitializer> = async (
+export const handleAddRole: RequestHandler<Role, RoleInitializer> = async (
 	req,
 	res,
 ) => {
 	try {
 		const role = await roleModel.addRole(req.body);
-		res.status(StatusCodes.CREATED).json(role);
+		res.status(StatusCodes.CREATED).json({
+			...role,
+			date_added: role.date_added.toISOString(),
+		});
 	} catch (error) {
 		if (error instanceof Error) {
 			res

--- a/apps/api/src/models/__tests__/admin.model.integration.test.ts
+++ b/apps/api/src/models/__tests__/admin.model.integration.test.ts
@@ -41,7 +41,7 @@ describe("login", () => {
 				);
 
 				expect(id).toBeDefined();
-				expect(expiry).toBeInstanceOf(Date);
+				expect(new Date(expiry).getTime()).not.toBeNaN();
 			});
 
 			it("stores the session in the database", async () => {
@@ -64,7 +64,7 @@ describe("login", () => {
 
 				const { expiry } = await adminModel.login(admin.email, admin.password);
 
-				expect(expiry.valueOf()).toEqual(addHours(now, 2).valueOf());
+				expect(new Date(expiry).valueOf()).toEqual(addHours(now, 2).valueOf());
 			});
 		});
 

--- a/apps/api/src/models/admin.ts
+++ b/apps/api/src/models/admin.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from "crypto";
+import Session from "@repo/shared/generated/api/hire_me/Session";
 import DBAdmin from "@repo/shared/generated/db/hire_me/Admin";
 import DBSession, {
 	SessionId,
@@ -21,7 +22,7 @@ export enum AdminErrorCodes {
 async function login(
 	email: string,
 	password: string,
-): Promise<Pick<DBSession, "id" | "expiry">> {
+): Promise<Pick<Session, "id" | "expiry">> {
 	try {
 		const { password_hash, id: admin_id } = await db.one<
 			Pick<DBAdmin, "password_hash" | "id">
@@ -43,7 +44,10 @@ async function login(
 			[session_token, session_expiry, admin_id],
 		);
 
-		return session;
+		return {
+			...session,
+			expiry: session.expiry.toISOString(),
+		};
 	} catch (error) {
 		if (!isError(error)) {
 			throw error;

--- a/apps/api/src/models/company.ts
+++ b/apps/api/src/models/company.ts
@@ -1,6 +1,7 @@
-import DBCompany, {
-	DBCompanyInitializer,
-} from "@repo/shared/generated/db/hire_me/Company";
+import Company, {
+	CompanyInitializer,
+} from "@repo/shared/generated/api/hire_me/Company";
+import DBCompany from "@repo/shared/generated/db/hire_me/Company";
 import db from "./db";
 
 export enum companyErrorCodes {
@@ -11,7 +12,7 @@ async function addCompany({
 	name,
 	notes,
 	website,
-}: DBCompanyInitializer): Promise<DBCompany> {
+}: CompanyInitializer): Promise<Company> {
 	try {
 		const company = await db.oneOrNone<DBCompany>(
 			"SELECT id, name FROM company WHERE name = $1",
@@ -33,7 +34,7 @@ async function addCompany({
 	}
 }
 
-async function getCompanies(): Promise<DBCompany[]> {
+async function getCompanies(): Promise<Company[]> {
 	try {
 		const companies = await db.any<DBCompany>(
 			"SELECT id, name, notes, website FROM company ORDER BY name",

--- a/apps/api/src/models/requirement.ts
+++ b/apps/api/src/models/requirement.ts
@@ -1,3 +1,4 @@
+import Requirement from "@repo/shared/generated/api/hire_me/Requirement";
 import DBRequirement, {
 	DBRequirementInitializer,
 } from "@repo/shared/generated/db/hire_me/Requirement";
@@ -7,7 +8,7 @@ async function addRequirement({
 	role_id,
 	bonus,
 	description,
-}: DBRequirementInitializer): Promise<DBRequirement> {
+}: DBRequirementInitializer): Promise<Requirement> {
 	try {
 		const requirement = await db.one<DBRequirement>(
 			`INSERT INTO requirement (role_id, bonus, description)

--- a/apps/api/src/models/role.ts
+++ b/apps/api/src/models/role.ts
@@ -1,15 +1,9 @@
-import DBRole, {
-	DBRoleInitializer,
-} from "@repo/shared/generated/db/hire_me/Role";
+import { RoleInitializer } from "@repo/shared/generated/api/hire_me/Role";
+import DBRole from "@repo/shared/generated/db/hire_me/Role";
 import { RolePreview } from "@repo/shared/types/rolePreview";
 import db from "./db";
 
-async function addRole({
-	title,
-	company_id,
-	ad_url,
-	notes,
-}: DBRoleInitializer) {
+async function addRole({ title, company_id, ad_url, notes }: RoleInitializer) {
 	try {
 		const role = await db.one<DBRole>(
 			`INSERT INTO role (company_id, title, notes, ad_url) VALUES ($1, $2, $3, $4) 

--- a/packages/shared/generated/routes/company.ts
+++ b/packages/shared/generated/routes/company.ts
@@ -1,16 +1,16 @@
-import DBCompany, { DBCompanyInitializer } from "../db/hire_me/Company.js";
+import Company, { CompanyInitializer } from "../api/hire_me/Company.js";
 
 // This file is generated and should not be modified directly.
 export interface AddCompanyRequest {
 	method: "post";
 	path: "/api/company";
-	responseBody: DBCompany;
-	body: DBCompanyInitializer;
+	responseBody: Company;
+	body: CompanyInitializer;
 }
 
 export interface GetCompaniesRequest {
 	method: "get";
 	path: "/api/companies";
-	responseBody: DBCompany[];
+	responseBody: Company[];
 	body: null;
 }

--- a/packages/shared/generated/routes/requirement.ts
+++ b/packages/shared/generated/routes/requirement.ts
@@ -1,11 +1,11 @@
-import DBRequirement, {
-	DBRequirementInitializer,
-} from "../db/hire_me/Requirement.js";
+import Requirement, {
+	RequirementInitializer,
+} from "../api/hire_me/Requirement.js";
 
 // This file is generated and should not be modified directly.
 export interface AddRequirementRequest {
 	method: "post";
 	path: "/api/requirement";
-	responseBody: DBRequirement;
-	body: DBRequirementInitializer;
+	responseBody: Requirement;
+	body: RequirementInitializer;
 }

--- a/packages/shared/generated/routes/role.ts
+++ b/packages/shared/generated/routes/role.ts
@@ -1,12 +1,12 @@
 import { RolePreviewJson } from "../../types/rolePreview.js";
-import DBRole, { DBRoleInitializer } from "../db/hire_me/Role.js";
+import Role, { RoleInitializer } from "../api/hire_me/Role.js";
 
 // This file is generated and should not be modified directly.
 export interface AddRoleRequest {
 	method: "post";
 	path: "/api/role";
-	responseBody: DBRole;
-	body: DBRoleInitializer;
+	responseBody: Role;
+	body: RoleInitializer;
 }
 
 export interface GetRolePreviewsRequest {


### PR DESCRIPTION
This PR ensures the correct generated types are being used:
- db types from `@repo/shared/generated/db` for DB query results
- API types from `@repo/shared/generated/api` for values returned by model functions
- API types from `@repo/shared/generated/api` for values provided in request bodies